### PR TITLE
Release v1.0.4

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
       - arm64
     goarm:
       - "6"
-    main: ./cmd/freeport
+    main: ./cmd
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
 


### PR DESCRIPTION
- [fix: wrong path for `main` package](https://github.com/ansidev/freeport/commit/8d22b9034460bada15322e8b7786929d2f08bd48)